### PR TITLE
Update btcde.py (self.nonce)

### DIFF
--- a/btcde.py
+++ b/btcde.py
@@ -107,7 +107,7 @@ class Connection(object):
         self.api_key = api_key
         self.api_secret = api_secret
         # set initial self.nonce
-        self.nonce = int(time.time() * 1000000) # avoid "invalid nonce" error for frequent API calls by raising the number
+        self.nonce = int(time.time() * 1000000)
         # Bitcoin.de API URI
         self.apihost = 'https://api.bitcoin.de'
         self.apiversion = 'v2'

--- a/btcde.py
+++ b/btcde.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 requests_log = logging.getLogger("requests.packages.urllib3")
 requests_log.propagate = True
 
-__version__ = '2.2'
+__version__ = '2.3'
 
 # disable unsecure SSL warning
 requests.packages.urllib3.disable_warnings()
@@ -107,7 +107,7 @@ class Connection(object):
         self.api_key = api_key
         self.api_secret = api_secret
         # set initial self.nonce
-        self.nonce = int(time.time())
+        self.nonce = int(time.time() * 1000) # avoid "invalid nonce" error for frequent API calls by raising the number
         # Bitcoin.de API URI
         self.apihost = 'https://api.bitcoin.de'
         self.apiversion = 'v2'

--- a/btcde.py
+++ b/btcde.py
@@ -125,7 +125,7 @@ class Connection(object):
 
     def set_header(self, url, method, encoded_string):
         # raise self.nonce before using
-        self.nonce += 1
+        self.nonce = int(time.time()*1000) + 1
         if method == 'POST':
             md5_encoded_query_string = hashlib.md5(encoded_string.encode()).hexdigest()
         else:

--- a/btcde.py
+++ b/btcde.py
@@ -125,7 +125,7 @@ class Connection(object):
 
     def set_header(self, url, method, encoded_string):
         # raise self.nonce before using
-        self.nonce = int(time.time() * 1000000) + 1
+        self.nonce = int(time.time() * 1000000)
         if method == 'POST':
             md5_encoded_query_string = hashlib.md5(encoded_string.encode()).hexdigest()
         else:

--- a/btcde.py
+++ b/btcde.py
@@ -107,7 +107,7 @@ class Connection(object):
         self.api_key = api_key
         self.api_secret = api_secret
         # set initial self.nonce
-        self.nonce = int(time.time() * 1000) # avoid "invalid nonce" error for frequent API calls by raising the number
+        self.nonce = int(time.time() * 1000000) # avoid "invalid nonce" error for frequent API calls by raising the number
         # Bitcoin.de API URI
         self.apihost = 'https://api.bitcoin.de'
         self.apiversion = 'v2'
@@ -125,7 +125,7 @@ class Connection(object):
 
     def set_header(self, url, method, encoded_string):
         # raise self.nonce before using
-        self.nonce = int(time.time()*1000) + 1
+        self.nonce = int(time.time() * 1000000) + 1
         if method == 'POST':
             md5_encoded_query_string = hashlib.md5(encoded_string.encode()).hexdigest()
         else:

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -34,7 +34,7 @@ class TestBtcdeAPIDocu(TestCase):
 
     def verifySignature(self, url, method, params):
         '''To verify API Signature.'''
-        self.XAPINONCE += 1
+        self.XAPINONCE = int(time.time()*1000) + 1
         self.url, self.encoded_string = self.sortParams(url, params)
         if method == 'POST':
             md5_encoded_query_string = hashlib.md5(self.encoded_string.encode()

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -6,6 +6,7 @@ from mock import patch
 import json
 import btcde
 from decimal import Decimal
+import time
 
 
 @patch('btcde.log')

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -34,7 +34,7 @@ class TestBtcdeAPIDocu(TestCase):
 
     def verifySignature(self, url, method, params):
         '''To verify API Signature.'''
-        self.XAPINONCE = int(time.time()*1000) + 1
+        self.XAPINONCE = int(time.time() * 1000000) + 1
         self.url, self.encoded_string = self.sortParams(url, params)
         if method == 'POST':
             md5_encoded_query_string = hashlib.md5(self.encoded_string.encode()

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -77,8 +77,8 @@ class TestBtcdeAPIDocu(TestCase):
                               params.get('price'))
         history = m.request_history
         request_signature = history[0].headers.get('X-API-SIGNATURE')
-        verified_signature = self.verifySignature(self.conn.orderuri, self.conn.nonce,
-                                                  'POST',
+        verified_signature = self.verifySignature(self.conn.orderuri,
+                                                  'POST', self.conn.nonce,
                                                   params)
         self.assertEqual(request_signature, verified_signature)
         self.assertTrue(mock_logger.debug.called)
@@ -93,8 +93,8 @@ class TestBtcdeAPIDocu(TestCase):
                                 params.get('trading_pair'))
         history = m.request_history
         request_signature = history[0].headers.get('X-API-SIGNATURE')
-        verified_signature = self.verifySignature(self.conn.orderuri, self.conn.nonce,
-                                                  'GET',
+        verified_signature = self.verifySignature(self.conn.orderuri,
+                                                  'GET', self.conn.nonce,
                                                   params)
         self.assertEqual(request_signature, verified_signature)
         self.assertTrue(mock_logger.debug.called)

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -6,7 +6,6 @@ from mock import patch
 import json
 import btcde
 from decimal import Decimal
-import time
 
 
 @patch('btcde.log')
@@ -33,9 +32,9 @@ class TestBtcdeAPIDocu(TestCase):
             self.url = url
         return self.url, self.encoded_string
 
-    def verifySignature(self, url, method, params):
+    def verifySignature(self, url, method, nonce, params):
         '''To verify API Signature.'''
-        self.XAPINONCE = int(time.time() * 1000000) + 1
+        self.XAPINONCE = nonce
         self.url, self.encoded_string = self.sortParams(url, params)
         if method == 'POST':
             md5_encoded_query_string = hashlib.md5(self.encoded_string.encode()
@@ -78,7 +77,7 @@ class TestBtcdeAPIDocu(TestCase):
                               params.get('price'))
         history = m.request_history
         request_signature = history[0].headers.get('X-API-SIGNATURE')
-        verified_signature = self.verifySignature(self.conn.orderuri,
+        verified_signature = self.verifySignature(self.conn.orderuri, self.conn.nonce,
                                                   'POST',
                                                   params)
         self.assertEqual(request_signature, verified_signature)
@@ -94,7 +93,7 @@ class TestBtcdeAPIDocu(TestCase):
                                 params.get('trading_pair'))
         history = m.request_history
         request_signature = history[0].headers.get('X-API-SIGNATURE')
-        verified_signature = self.verifySignature(self.conn.orderuri,
+        verified_signature = self.verifySignature(self.conn.orderuri, self.conn.nonce,
                                                   'GET',
                                                   params)
         self.assertEqual(request_signature, verified_signature)
@@ -109,7 +108,7 @@ class TestBtcdeAPIDocu(TestCase):
         history = m.request_history
         request_signature = history[0].headers.get('X-API-SIGNATURE')
         url = self.conn.orderuri + "/" + order_id + "/" + trading_pair
-        verified_signature = self.verifySignature(url, 'DELETE', {})
+        verified_signature = self.verifySignature(url, 'DELETE', self.conn.nonce, {})
         self.assertEqual(request_signature, verified_signature)
         self.assertTrue(mock_logger.debug.called)
 


### PR DESCRIPTION
Avoid "invalid nonce" error for frequent API calls by raising the number by 1000.

**Edit: This doesn't help with parallel API calls on the same connection unfortunately... Only when creating new connections. Any idea on how to generate the nonce so that parallel calls don't pose a problem?**