### PR TITLE
Order url parameters alphabetically

### DIFF
--- a/btcde.py
+++ b/btcde.py
@@ -65,7 +65,7 @@ class ParameterBuilder(object):
 
     def create_url(self, uri):
         if self.params:
-            self.encoded_string = urlencode(self.params)
+            self.encoded_string = urlencode(sorted(self.params.items()))
             self.url = uri + '?' + self.encoded_string
         else:
             self.encoded_string = ''


### PR DESCRIPTION
This fixes https://github.com/peshay/btcde/issues/44. Like stated in the documentation the parameters in the URL must be sorted alphabetically.

