### PR TITLE
add ssl_verify 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ import btcde
 # create a object for the connection settings
 api_key = <YourAPIKey>
 api_secret = <YourAPISecret>
-conn = btcde.Connection(api_key, api_secret)
+# ssl_verify - Set to True or False to enable or disable SSL verification
+conn = btcde.Connection(api_key, api_secret, ssl_verify=True)
 orderbook = conn.showOrderbook('buy', 'btceur')
 print(f'API Credits Left: {orderbook["credits"]}')
 orders = orderbook['orders']

--- a/btcde.py
+++ b/btcde.py
@@ -67,10 +67,10 @@ class ParameterBuilder(object):
 
 
     TRADING_PAIRS = ['btceur', 'bcheur', 'etheur', 'btgeur', 'bsveur', 'ltceur',
-                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc', 'xrpeur']
+                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc', 'xrpeur', 'usdteur', 'btcusdt', 'ethusdt']
     ORDER_TYPES = ['buy', 'sell']
     CURRENCIES = ['btc', 'bch', 'eth', 'btg', 'bsv', 'ltc',
-                  'iota', 'dash', 'gnt', 'xrp']
+                  'iota', 'dash', 'gnt', 'xrp', 'usdt']
     BANK_SEATS = ['AT', 'BE', 'BG', 'CH', 'CY', 'CZ',
                   'DE', 'DK', 'EE', 'ES', 'FI', 'FR',
                   'GB', 'GR', 'HR', 'HU', 'IE', 'IS',

--- a/btcde.py
+++ b/btcde.py
@@ -107,7 +107,7 @@ def HandleAPIErrors(r):
 
 class Connection(object):
     """To provide connection credentials to the trading API"""
-    def __init__(self, api_key, api_secret):
+    def __init__(self, api_key, api_secret, ssl_verify=False):
         self.api_key = api_key
         self.api_secret = api_secret
         # set initial self.nonce
@@ -116,6 +116,7 @@ class Connection(object):
         self.apihost = 'https://api.bitcoin.de'
         self.apiversion = 'v4'
         self.apibase = f'{self.apihost}/{self.apiversion}/'
+        self.ssl_verify = ssl_verify # avoid warnings for ssl-cert
 
     def build_hmac_sign(self, md5string, method, url):
         hmac_data = '#'.join([method, url, self.api_key, str(self.nonce), md5string])
@@ -142,13 +143,13 @@ class Connection(object):
     def send_request(self, url, method, header, encoded_string):
         if method == 'GET':
             r = requests.get(url, headers=(header),
-                             stream=True, verify=False)
+                             stream=True, verify=self.ssl_verify)
         elif method == 'POST':
             r = requests.post(url, headers=(header), data=encoded_string,
-                              stream=True, verify=False)
+                              stream=True, verify=self.ssl_verify)
         elif method == 'DELETE':
             r = requests.delete(url, headers=(header),
-                                stream=True, verify=False)
+                                stream=True, verify=self.ssl_verify)
         return r
 
     def APIConnect(self, method, params):

--- a/btcde.py
+++ b/btcde.py
@@ -67,10 +67,10 @@ class ParameterBuilder(object):
 
 
     TRADING_PAIRS = ['btceur', 'bcheur', 'etheur', 'btgeur', 'bsveur', 'ltceur',
-                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc']
+                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc', 'xrpeur']
     ORDER_TYPES = ['buy', 'sell']
     CURRENCIES = ['btc', 'bch', 'eth', 'btg', 'bsv', 'ltc',
-                  'iota', 'dash', 'gnt']
+                  'iota', 'dash', 'gnt', 'xrp']
     BANK_SEATS = ['AT', 'BE', 'BG', 'CH', 'CY', 'CZ',
                   'DE', 'DK', 'EE', 'ES', 'FI', 'FR',
                   'GB', 'GR', 'HR', 'HU', 'IE', 'IS',

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -489,7 +489,7 @@ class TestBtcdeAPIDocu(TestCase):
         '''Test the allowed trading pairs.'''
         i = 0
         for pair in ['btceur', 'bcheur', 'etheur', 'btgeur', 'bsveur', 'ltceur',
-                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc']:
+                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc', 'xrpeur' ]:
             params = {'trading_pair': pair}
             base_url = f'https://api.bitcoin.de/v4/{pair}/rates'
             response = self.sampleData('showRates')
@@ -505,7 +505,7 @@ class TestBtcdeAPIDocu(TestCase):
         '''Test the allowed currencies.'''
         i = 0
         for curr in ['btc', 'bch', 'eth', 'btg', 'bsv', 'ltc',
-                     'iota', 'dash', 'gnt']:
+                     'iota', 'dash', 'gnt', 'xrp']:
             base_url = f'https://api.bitcoin.de/v4/{curr}/account/ledger'
             url_args = '?currency={}'.format(curr)
             response = self.sampleData('showAccountLedger')

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -6,6 +6,9 @@ from mock import patch
 import json
 import btcde
 from decimal import Decimal
+from mock import patch
+from unittest.mock import patch
+
 
 from urllib.parse import urlencode
 
@@ -489,7 +492,7 @@ class TestBtcdeAPIDocu(TestCase):
         '''Test the allowed trading pairs.'''
         i = 0
         for pair in ['btceur', 'bcheur', 'etheur', 'btgeur', 'bsveur', 'ltceur',
-                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc', 'xrpeur' ]:
+                     'iotabtc', 'dashbtc', 'gntbtc', 'ltcbtc', 'xrpeur', 'usdteur', 'btcusdt', 'ethusdt' ]:
             params = {'trading_pair': pair}
             base_url = f'https://api.bitcoin.de/v4/{pair}/rates'
             response = self.sampleData('showRates')
@@ -505,7 +508,7 @@ class TestBtcdeAPIDocu(TestCase):
         '''Test the allowed currencies.'''
         i = 0
         for curr in ['btc', 'bch', 'eth', 'btg', 'bsv', 'ltc',
-                     'iota', 'dash', 'gnt', 'xrp']:
+                     'iota', 'dash', 'gnt', 'xrp', 'usdt']:
             base_url = f'https://api.bitcoin.de/v4/{curr}/account/ledger'
             url_args = '?currency={}'.format(curr)
             response = self.sampleData('showAccountLedger')

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -53,7 +53,7 @@ class TestBtcdeAPIDocu(TestCase):
     def setUp(self):
         self.XAPIKEY = 'f00b4r'
         self.XAPISECRET = 'b4rf00'
-        self.conn = btcde.Connection(self.XAPIKEY, self.XAPISECRET)
+        self.conn = btcde.Connection(self.XAPIKEY, self.XAPISECRET, ssl_verify=True)
         self.XAPINONCE = self.conn.nonce
 
     def tearDown(self):
@@ -549,7 +549,7 @@ class TestBtcdeExceptions(TestCase):
     def setUp(self):
         self.XAPIKEY = 'f00b4r'
         self.XAPISECRET = 'b4rf00'
-        self.conn = btcde.Connection(self.XAPIKEY, self.XAPISECRET)
+        self.conn = btcde.Connection(self.XAPIKEY, self.XAPISECRET, ssl_verify=True)
         self.XAPINONCE = self.conn.nonce
 
     def tearDown(self):


### PR DESCRIPTION
add ssl_verify option - Set to True or False to enable or disable SSL verification


`(.venv) ~/btcde$ pytest tests/
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.2, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/j4c0b1/btcde
plugins: requests-mock-1.11.0
collected 44 items                                                                                                                                                                        

tests/test_btcde_func.py ............................................                                                                                                               [100%]

=================================================================================== 44 passed in 1.49s ====================================================================================
(.venv) ~/btcde$ `