### PR TITLE
Fix: executeTrade not possible due to payment_option set to 1 (default) if not specified

### DIFF
--- a/btcde.py
+++ b/btcde.py
@@ -266,12 +266,14 @@ class Connection(object):
         p = ParameterBuilder({}, {}, uri)
         return self.APIConnect('GET', p)
 
-    def executeTrade(self, trading_pair, order_id, order_type, amount):
+    def executeTrade(self, trading_pair, order_id, order_type, amount, payment_option=2):
         """Buy/Sell on a specific Order."""
         uri = f'{self.apibase}{trading_pair}/trades/{order_id}'
         params = { 'type': order_type,
-                   'amount_currency_to_trade': amount}
-        avail_params = ['type', 'amount_currency_to_trade']
+                   'amount_currency_to_trade': amount,
+                   'payment_option': payment_option
+                 } 
+        avail_params = ['type', 'amount_currency_to_trade', 'payment_option']
         p = ParameterBuilder(avail_params, params, uri)
         return self.APIConnect('POST', p)
 

--- a/tests/test_btcde_func.py
+++ b/tests/test_btcde_func.py
@@ -252,7 +252,9 @@ class TestBtcdeAPIDocu(TestCase):
         trading_pair = 'btceur'
         order_id = '1337'
         params = {'amount_currency_to_trade': '10',
-                  'type': 'buy'}
+                  'payment_option' : 2,
+                  'type': 'buy',
+                  }
         base_url = f'https://api.bitcoin.de/v4/{trading_pair}/trades/{order_id}'
         url_args = '?' + urlencode(params)
         response = self.sampleData('minimal')


### PR DESCRIPTION
With the current API Wrapper it is not possible to executeTrades. It is not possible to change the payment_option field (which is specified as a optional parameter in the docs). As its a optional Post Parameter, it is set to payment_option=1 on bitcoin.de side. 

However, since the Fidor bank shutdown a payment_option=1 (Express Trade) is not possible on the platform anymore. But the payment_option is still be set if not specified, resulting in an "71 - Express Trade not allowed" Error. (Which tbh should also be fixed on bitcoin.de side, as it does not make sense)

 As it was not possible to set the payment_option regardless, I added the field and changed the default value to 2 (SEPA-Buy) and also made the field optional, by overriding the method call parameter. 
 
 Optionally, rather then changing the default value in the method itself, we could allow for making the whole parameter optional with **args, so the payment_option field can still be set to the desired value when calling the method. However an existing codebase with older realeases might not work. 