### PR TITLE
Add public artifact hygiene guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,24 @@ permissions:
   id-token: write
 
 jobs:
+  public-artifact-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Public artifact hygiene
+        run: pre-commit run public-artifact-hygiene --all-files
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: public-artifact-hygiene
+        name: public artifact hygiene
+        entry: python tools/check_public_artifacts.py
+        language: python
+        pass_filenames: true
+        files: '(^|/)([^/]+[.](md|rst|txt|ya?ml|toml|ini|cfg|json)|MANIFEST|LICENSE)$'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,6 +3,10 @@ checks:
         code_rating: true
         duplicate_code: true
 
+filter:
+    excluded_paths:
+        - tools/*
+
 build:
   nodes:
     analysis:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ API Wrapper for [Bitcoin.de Trading API](https://www.bitcoin.de/de/api/tapi/doc)
 
 Requires: requests
 
+## Contributor checks
+
+Before publishing pull request text, comments, commit messages, or docs, run the [public artifact hygiene guard](docs/public-artifact-hygiene.md). It is available through pre-commit and runs in CI.
+
 ## Install btcde.py
 
 You can install the btcde module via pip

--- a/docs/public-artifact-hygiene.md
+++ b/docs/public-artifact-hygiene.md
@@ -1,0 +1,40 @@
+# Public artifact hygiene
+
+Public artifacts include pull request text, review comments, commit messages, release notes, and repository docs. Keep those artifacts safe to publish.
+
+## Run locally
+
+Install and run the hook from the repository root:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install pre-commit
+pre-commit install --install-hooks
+pre-commit run public-artifact-hygiene --all-files
+```
+
+For text that is not stored in the repo yet, pipe it through the same guard before publishing:
+
+```bash
+cat pr-body.md | python3 tools/check_public_artifacts.py --stdin --label pr-body.md
+```
+
+CI runs the same pre-commit hook on pull requests.
+
+## What the guard blocks
+
+The check fails on public-facing files when it finds:
+
+- Local workstation or agent runtime paths.
+- Prompt text, private model notes, scratch notes, or private routing metadata.
+- Authorization headers, credential assignments, tokens, or private key blocks.
+- Trading, payment, or banking write-operation wording that implies use of real accounts or funds.
+- Escaped newline markers in prose where real line breaks should be used.
+
+## Fix and rerun
+
+1. Replace private details with neutral placeholders such as `<PROJECT_REPO>`, `<LOCAL_PATH_REDACTED>`, or `<REDACTED_SECRET>`.
+2. Rewrite unsafe prose so it describes mocked or fixture-based behavior, not real account or funds movement.
+3. Convert escaped newline markers in commit or PR text into real line breaks.
+4. Rerun `pre-commit run public-artifact-hygiene --all-files` and, for PR text, rerun the standard input command above.

--- a/tools/check_public_artifacts.py
+++ b/tools/check_public_artifacts.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """Check public-facing repository artifacts for unsafe disclosure patterns."""
-from __future__ import annotations
-
 import argparse
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import List, Optional, Pattern, Tuple
 
 
 PUBLIC_SUFFIXES = {
@@ -38,10 +37,10 @@ SKIP_DIRS = {
 class Rule:
     code: str
     description: str
-    pattern: re.Pattern[str]
+    pattern: Pattern
 
 
-def _rx(value: str, flags: int = re.IGNORECASE) -> re.Pattern[str]:
+def _rx(value: str, flags: int = re.IGNORECASE) -> Pattern:
     return re.compile(value, flags)
 
 
@@ -102,8 +101,8 @@ def is_probably_binary(path: Path) -> bool:
     return b"\0" in chunk
 
 
-def public_artifact_paths(root: Path) -> list[Path]:
-    paths: list[Path] = []
+def public_artifact_paths(root: Path) -> List[Path]:
+    paths = []  # type: List[Path]
     for path in root.rglob("*"):
         if path.is_dir():
             continue
@@ -122,14 +121,14 @@ def should_scan(path: Path) -> bool:
     return path.suffix.lower() in PUBLIC_SUFFIXES or path.name in {"MANIFEST", "LICENSE"}
 
 
-def line_col(text: str, offset: int) -> tuple[int, int]:
+def line_col(text: str, offset: int) -> Tuple[int, int]:
     line = text.count("\n", 0, offset) + 1
     line_start = text.rfind("\n", 0, offset) + 1
     return line, offset - line_start + 1
 
 
-def check_text(label: str, text: str) -> list[str]:
-    failures: list[str] = []
+def check_text(label: str, text: str) -> List[str]:
+    failures = []  # type: List[str]
     for rule in RULES:
         for match in rule.pattern.finditer(text):
             line, col = line_col(text, match.start())
@@ -137,7 +136,7 @@ def check_text(label: str, text: str) -> list[str]:
     return failures
 
 
-def decode_path(path: Path) -> str | None:
+def decode_path(path: Path) -> Optional[str]:
     if is_probably_binary(path):
         return None
     try:
@@ -146,7 +145,7 @@ def decode_path(path: Path) -> str | None:
         return path.read_text(encoding="utf-8", errors="replace")
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Check public-facing artifacts for local paths, prompts, secrets, and malformed escaped newlines."
     )
@@ -155,7 +154,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--label", default="<stdin>", help="Label to use with --stdin diagnostics.")
     args = parser.parse_args(argv)
 
-    failures: list[str] = []
+    failures = []  # type: List[str]
     if args.stdin:
         failures.extend(check_text(args.label, sys.stdin.read()))
     else:

--- a/tools/check_public_artifacts.py
+++ b/tools/check_public_artifacts.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check public-facing repository artifacts for unsafe disclosure patterns."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PUBLIC_SUFFIXES = {
+    ".cfg",
+    ".ini",
+    ".json",
+    ".md",
+    ".rst",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+}
+
+
+@dataclass(frozen=True)
+class Rule:
+    code: str
+    description: str
+    pattern: re.Pattern[str]
+
+
+def _rx(value: str, flags: int = re.IGNORECASE) -> re.Pattern[str]:
+    return re.compile(value, flags)
+
+
+RULES = [
+    Rule(
+        "literal-escaped-newline",
+        "literal escaped newline sequence; use real line breaks in public prose",
+        _rx(r"\\n", 0),
+    ),
+    Rule(
+        "openclaw-path",
+        "internal agent/runtime path or metadata",
+        _rx(r"(?:/root|/home/[A-Za-z0-9_.-]+)/[.]openclaw\b|[.]openclaw\b|workspace-[A-Za-z0-9_.-]+|agents/[^\s]+/sessions"),
+    ),
+    Rule(
+        "local-user-path",
+        "local workstation path",
+        _rx(r"(?:/Users/[A-Za-z0-9_.-]+\b|/mnt/data\b|C:\\\\Users\\\\[A-Za-z0-9_.-]+)"),
+    ),
+    Rule(
+        "prompt-leakage",
+        "prompt, hidden reasoning, or scratchpad leakage",
+        _rx(r"\b(?:system|developer) prompt\b|chain[- ]of[- ]thought|hidden reasoning|scratchpad|subagent context"),
+    ),
+    Rule(
+        "board-routing-leakage",
+        "private board, owner, or routing metadata",
+        _rx(r"\bplanka[_-][A-Za-z0-9_-]+\b|\bOwner:\s|\binternal board routing\b|\bboard id\b|\bcard id\b"),
+    ),
+    Rule(
+        "auth-header",
+        "authorization header or bearer token material",
+        _rx(r"\bAuthorization\s*:\s*(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}"),
+    ),
+    Rule(
+        "secret-assignment",
+        "secret or credential assignment with a non-placeholder value",
+        _rx(r"\b(?:API[_-]?KEY|API[_-]?SECRET|X[-_]?API[-_]?KEY|X[-_]?API[-_]?SIGNATURE|HMAC[_-]?SIGNATURE|WEBHOOK[_-]?SECRET|REPO[_-]?(?:USER|PASS)|SVC[_-]?PASS|PRIVATE[_-]?KEY|AWS[_-]?SECRET[_-]?ACCESS[_-]?KEY|AWS[_-]?SESSION[_-]?TOKEN|BUNQ[_-]?API[_-]?KEY)\b\s*[:=]\s*(?![<{$][A-Z0-9_{}$.-]+[>}]?\b)[\"']?[A-Za-z0-9_./+=:-]{8,}"),
+    ),
+    Rule(
+        "private-key-block",
+        "private key block",
+        _rx(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    ),
+    Rule(
+        "live-write-token",
+        "live trading, payment, or banking write-operation wording",
+        _rx(r"\b(?:live|real|production)\s+(?:trade|trading|order|payment|withdrawal|deposit|bank transfer)\b|\b(?:execute|place|submit|cancel|withdraw|deposit|pay|transfer)\s+(?:a\s+)?(?:live|real|production)?\s*(?:trade|order|payment|withdrawal|deposit|bank transfer)\b"),
+    ),
+]
+
+
+def is_probably_binary(path: Path) -> bool:
+    try:
+        chunk = path.read_bytes()[:4096]
+    except OSError:
+        return True
+    return b"\0" in chunk
+
+
+def public_artifact_paths(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_dir():
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.suffix.lower() in PUBLIC_SUFFIXES or path.name in {"MANIFEST", "LICENSE"}:
+            paths.append(path)
+    return paths
+
+
+def should_scan(path: Path) -> bool:
+    if not path.exists() or not path.is_file():
+        return False
+    if any(part in SKIP_DIRS for part in path.parts):
+        return False
+    return path.suffix.lower() in PUBLIC_SUFFIXES or path.name in {"MANIFEST", "LICENSE"}
+
+
+def line_col(text: str, offset: int) -> tuple[int, int]:
+    line = text.count("\n", 0, offset) + 1
+    line_start = text.rfind("\n", 0, offset) + 1
+    return line, offset - line_start + 1
+
+
+def check_text(label: str, text: str) -> list[str]:
+    failures: list[str] = []
+    for rule in RULES:
+        for match in rule.pattern.finditer(text):
+            line, col = line_col(text, match.start())
+            failures.append(f"{label}:{line}:{col}: {rule.code}: {rule.description}")
+    return failures
+
+
+def decode_path(path: Path) -> str | None:
+    if is_probably_binary(path):
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check public-facing artifacts for local paths, prompts, secrets, and malformed escaped newlines."
+    )
+    parser.add_argument("paths", nargs="*", help="Files to check. If omitted, scan public artifact files in the repository.")
+    parser.add_argument("--stdin", action="store_true", help="Check text from standard input as a public artifact.")
+    parser.add_argument("--label", default="<stdin>", help="Label to use with --stdin diagnostics.")
+    args = parser.parse_args(argv)
+
+    failures: list[str] = []
+    if args.stdin:
+        failures.extend(check_text(args.label, sys.stdin.read()))
+    else:
+        if args.paths:
+            candidates = [Path(path) for path in args.paths]
+        else:
+            candidates = public_artifact_paths(Path.cwd())
+        for path in candidates:
+            if not should_scan(path):
+                continue
+            text = decode_path(path)
+            if text is None:
+                continue
+            failures.extend(check_text(str(path), text))
+
+    if failures:
+        print("Public artifact hygiene check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print("\nReplace sensitive details with neutral placeholders, convert escaped newline sequences to real line breaks, then rerun the check.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a repo-local pre-commit hook that scans public-facing artifacts for escaped newline markers, local/internal metadata, prompt or routing leakage, credential material, and real account write-operation wording.
- Run the same hook in CI as a pull request check.
- Document how contributors can install, run, interpret, fix, and rerun the guard locally and for draft PR text.

## Tests
- `pre-commit install --install-hooks`
- `pre-commit run public-artifact-hygiene --all-files`
- `ruff check tools/check_public_artifacts.py btcde.py tests`
- `python -m pytest`
- `python -m build`
- `twine check dist/*` (passes with existing package metadata warnings)
- Negative samples confirmed the guard blocks escaped newline markers, local/internal metadata, prompt or routing leakage, credential material, and real account write-operation wording.

## Risk
- Low runtime risk: this changes repository hygiene checks, docs, and CI only.
- No trading functionality changes and no release or publish action.

## Follow-ups
- None.
