### PR TITLE
fix: detect normal Windows user paths in artifact guard

### DIFF
--- a/tests/test_public_artifact_guard.py
+++ b/tests/test_public_artifact_guard.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import importlib.util
+
+
+def load_guard():
+    guard_path = Path(__file__).resolve().parents[1] / "tools" / "check_public_artifacts.py"
+    spec = importlib.util.spec_from_file_location("check_public_artifacts", guard_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_clean_public_artifacts_pass():
+    guard = load_guard()
+    text = (
+        "api_key = <YourAPIKey>\n"
+        "api_secret = ${EXAMPLE_SECRET}\n"
+        "conn = btcde.Connection(api_key, api_secret, ssl_verify=True)\n"
+    )
+    assert guard.check_text("README.md", text) == []
+
+
+def test_literal_escaped_newline_is_flagged_in_docs():
+    guard = load_guard()
+    findings = guard.check_text("README.md", "Keep the line one\\nline two example.\n")
+    assert any("literal-escaped-newline" in finding for finding in findings)
+
+
+def test_secret_assignment_is_flagged():
+    guard = load_guard()
+    findings = guard.check_text(
+        "README.md",
+        "".join(["api", "_secret = \"", "AbCdEfGh1234567890IjKlMnOpQrStUv", "\"\n"]),
+    )
+    assert any("secret-assignment" in finding for finding in findings)
+
+
+def test_windows_local_path_is_flagged():
+    guard = load_guard()
+    findings = guard.check_text(
+        "notes.txt",
+        "Open it from C:\\Users\\alice\\AppData\\Roaming\\btcde\\config.ini\n",
+    )
+    assert any("local-user-path" in finding for finding in findings)

--- a/tools/check_public_artifacts.py
+++ b/tools/check_public_artifacts.py
@@ -58,7 +58,7 @@ RULES = [
     Rule(
         "local-user-path",
         "local workstation path",
-        _rx(r"(?:/Users/[A-Za-z0-9_.-]+\b|/mnt/data\b|C:\\\\Users\\\\[A-Za-z0-9_.-]+)"),
+        _rx(r"(?:/Users/[A-Za-z0-9_.-]+\b|/mnt/data\b|C:\\Users\\[A-Za-z0-9_.-]+)"),
     ),
     Rule(
         "prompt-leakage",


### PR DESCRIPTION
## Summary
- Fix the public-artifact guard to match normal Windows user paths under `C:\Users\...`
- Add a test that proves a typical Windows user path is flagged

## Gates
- pre-commit run public-artifact-hygiene --all-files ✅
- ruff check btcde.py tests tools ✅
- pytest ✅