### PR TITLE
docs: standardize README badges and add governance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS
+
+This repository accepts AI-assisted contributions.
+
+## Guardrails
+- Keep changes small and reviewable.
+- Be careful with trading and write endpoints; do not change their behavior without explicit intent.
+- Do not commit secrets, API keys, or personal data.
+- Run the public artifact hygiene guard (pre-commit) before publishing PR text, commits, or docs.
+
+## Required Human Checks
+- Review every AI-generated change before merge.
+- Validate API request/response handling and credit-cost annotations.
+- Ensure docs match implemented methods.
+
+## Attribution
+A concise note such as "AI-assisted" in the PR description is recommended for transparency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for contributing to btcde.py.
+
+## Requirements
+- Python 3.x
+- `pip`
+
+## Development Setup
+```bash
+pip install -e .
+pip install -r tests/requirements.txt
+pre-commit install --install-hooks
+pytest
+```
+
+## Branch and Commit Guidelines
+- Create a feature branch from `master`.
+- Use Conventional Commits, e.g.:
+  - `feat: add withdrawal endpoint`
+  - `fix: handle empty orderbook response`
+  - `docs: clarify API credit costs`
+
+## Pull Request Checklist
+- Keep changes focused and minimal.
+- Add or update tests for behavior changes.
+- Update docs (method list, credit costs) when behavior changes.
+- Run `pre-commit run --all-files` before opening a PR.
+- Ensure CI is green.
+
+## Security and Secrets
+- Never commit real API keys or secrets.
+- For vulnerabilities, follow `SECURITY.md`.
+
+## Review Policy
+- All PRs require human review before merge.
+- AI-assisted changes are welcome, but maintainers are responsible for final correctness.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 > Python SDK modernization for bitcoin.de with explicit separation between read-only surfaces and trading/write risk.
 
 [![CI](https://github.com/peshay/btcde/actions/workflows/ci.yml/badge.svg)](https://github.com/peshay/btcde/actions/workflows/ci.yml)
-[![Python version](https://img.shields.io/pypi/pyversions/btcde.svg)](https://pypi.python.org/pypi/btcde)
-[![license](https://img.shields.io/github/license/peshay/btcde.svg)](https://github.com/peshay/btcde/blob/master/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/btcde)](https://pypi.org/project/btcde/)
+[![Python version](https://img.shields.io/pypi/pyversions/btcde)](https://pypi.org/project/btcde/)
+[![License](https://img.shields.io/github/license/peshay/btcde)](LICENSE)
 
-[![Support via bunq](https://img.shields.io/badge/Support-bunq-00A1E0?style=flat-square&logo=bunq&logoColor=white)](https://bunq.me/ahu)
+[![Support via bunq](https://img.shields.io/badge/Support-bunq-00A1E0?style=flat-square&logo=bunq&logoColor=white)](https://bunq.me/ahuservices?description=btcde-maintenance-support)
 
 API Wrapper for [Bitcoin.de Trading API](https://www.bitcoin.de/de/api/tapi/doc)
 
@@ -335,4 +336,4 @@ Not yet implemented!
 
 ## Support
 
-Voluntary support helps fund ongoing freelance maintenance of this SDK. Support payments are appreciated but do not automatically create an entitlement to support, feature delivery, consulting, SLA, or invoice-based engagement.
+If this Python SDK is useful to you, you can [support its ongoing maintenance via bunq](https://bunq.me/ahuservices?description=btcde-maintenance-support). Support is voluntary and appreciated, but does not create any entitlement to support, features, consulting, an SLA, or invoice-based work.

--- a/README.md
+++ b/README.md
@@ -334,6 +334,13 @@ Not yet implemented!
 
 Not yet implemented!
 
+## Governance
+
+- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Security policy: [SECURITY.md](SECURITY.md)
+- AI-agent guide: [AGENTS.md](AGENTS.md)
+- License: [LICENSE](LICENSE)
+
 ## Support
 
 If this Python SDK is useful to you, you can [support its ongoing maintenance via bunq](https://bunq.me/ahuservices?description=btcde-maintenance-support). Support is voluntary and appreciated, but does not create any entitlement to support, features, consulting, an SLA, or invoice-based work.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+The `master` branch and the latest release on PyPI are the actively supported lines.
+
+## Reporting a Vulnerability
+Please do not open public issues for security vulnerabilities.
+
+Report privately to the maintainer and include:
+- affected component or function
+- impact and attack scenario
+- reproduction steps
+- suggested mitigation if available
+
+You will receive an acknowledgement as soon as possible, and we will coordinate remediation and disclosure timing.
+
+## Hardening Notes
+- Treat API keys and secrets as sensitive; never commit them or paste them into issues.
+- Keep `ssl_verify=True` in production.
+- Keep dependencies (`requests`, `urllib3`) up to date.


### PR DESCRIPTION
Part of a cross-repo README/governance standardization.

## Changes
- Add a PyPI version badge; align the license badge format.
- Unify the bunq support badge (bunq-blue + logo) and link (`bunq.me/ahuservices?description=btcde-maintenance-support`), on its own line.
- Tighten the Support section wording.
- Add `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md` and a Governance section linking them.

No code changes.

https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb)_