### PR TITLE
docs: add concrete security reporting contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The `master` branch and the latest release on PyPI are the actively supported li
 ## Reporting a Vulnerability
 Please do not open public issues for security vulnerabilities.
 
-Report privately to the maintainer and include:
+Report privately by email to security@ahu.services and include:
 - affected component or function
 - impact and attack scenario
 - reproduction steps


### PR DESCRIPTION
Follow-up to #71: add a concrete private reporting channel to SECURITY.md.

Uses `security@ahu.services`, consistent with the other repositories' SECURITY policies.

https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb)_