### PR TITLE
ci: add SonarQube Cloud analysis (consolidate coverage from Codecov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   public-artifact-hygiene:
@@ -57,8 +56,34 @@ jobs:
       - name: Tests with coverage
         run: pytest --cov=btcde --cov-report=xml tests/
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
         with:
-          use_oidc: true
-          files: ./coverage.xml
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r tests/requirements.txt
+          pip install pytest pytest-cov
+          pip install -e .
+
+      - name: Tests with coverage
+        run: pytest --cov=btcde --cov-report=xml tests/
+
+      - name: SonarQube Scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@v8.1.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 > Python SDK modernization for bitcoin.de with explicit separation between read-only surfaces and trading/write risk.
 
 [![CI](https://github.com/peshay/btcde/actions/workflows/ci.yml/badge.svg)](https://github.com/peshay/btcde/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=peshay_btcde&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=peshay_btcde)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=peshay_btcde&metric=coverage)](https://sonarcloud.io/summary/new_code?id=peshay_btcde)
 [![PyPI version](https://img.shields.io/pypi/v/btcde)](https://pypi.org/project/btcde/)
 [![Python version](https://img.shields.io/pypi/pyversions/btcde)](https://pypi.org/project/btcde/)
 [![License](https://img.shields.io/github/license/peshay/btcde)](LICENSE)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=peshay_btcde
+sonar.organization=peshay
+
+sonar.sources=btcde.py
+sonar.tests=tests
+
+sonar.python.version=3.10,3.11,3.12
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-codecov
 requests_mock
 mock
 pytest-cov


### PR DESCRIPTION
## Summary

Adds SonarQube Cloud static analysis + quality gate to btcde and consolidates coverage reporting onto SonarQube (removing the separate Codecov upload, per decision).

## Changes

- **`sonar-project.properties`** — project key `peshay_btcde`, org `peshay`, sources `btcde.py`, tests `tests/`, coverage from `coverage.xml`.
- **CI** — new `sonarqube` job runs the test suite with coverage and then `SonarSource/sonarqube-scan-action@v8.1.0`. The scan step is guarded by `if: env.SONAR_TOKEN != ''`, so the job stays **green/skipped until the secret exists** — no red CI in the meantime.
- **Codecov removed** — dropped the `codecov/codecov-action` upload step, the `id-token: write` permission, and `codecov` from `tests/requirements.txt`.
- **README** — added Quality Gate + Coverage badges.

## Required setup (you)

1. Create/import the project **`peshay_btcde`** in SonarQube Cloud org **`peshay`**.
2. Add repo Actions secret **`SONAR_TOKEN`**.
3. (Recommended) In the SonarCloud project, set *New Code* analysis and disable SonarCloud's "Automatic Analysis" so the CI-based scan is used.

Verified locally: `pytest --cov=btcde --cov-report=xml` → 48 passed, `coverage.xml` generated.

https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPPekbzyDXbhQKG3sPWkb)_